### PR TITLE
Paynter/bld0 6309/fix build issue with pip 26

### DIFF
--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib
 networkx>=2.0,<2.7
 numpy
-git+https://github.com/ObieCRE/openpyxl@b2edc9#egg=openpyxl
+git+https://github.com/ObieCRE/openpyxl@86bf690#egg=openpyxl
 python-dateutil
 pydot
 ruamel.yaml

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,7 +1,7 @@
 matplotlib
 networkx>=2.0,<2.7
 numpy
-git+https://github.com/ObieCRE/openpyxl@b2edc9#egg=openpyxl-3.0.10+obie.2
+git+https://github.com/ObieCRE/openpyxl@b2edc9#egg=openpyxl
 python-dateutil
 pydot
 ruamel.yaml

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     install_requires=[
         'networkx>=2.0,<2.7',
         'numpy',
-        'openpyxl @ git+https://github.com/ObieCRE/openpyxl@86bf69045ef6ce3eb8dd46c206e592f872c5f9f9#egg=openpyxl-3.0.10+obie.2',
+        'openpyxl @ git+https://github.com/ObieCRE/openpyxl@86bf69045ef6ce3eb8dd46c206e592f872c5f9f9#egg=openpyxl',
         'python-dateutil',
         'ruamel.yaml',
     ],


### PR DESCRIPTION
 - [ ] closes #xxxx
 - [ ] tests added / passed
 - [ ] passes ``tox``

Fixes build issue with pip 26 for invalid egg fragment.
See https://github.com/ObieCRE/excel-rater-to-api/pull/288
Updates commit referenced in requirements.txt to match the one from setup - this is one commit ahead and fixes an issue in versioning that also prevented install.

Successful install from pip 26 after fix:
<img width="1331" height="348" alt="image" src="https://github.com/user-attachments/assets/9ec5999a-4ae3-40a7-a7d9-b8ff69cc44f6" />
<img width="883" height="292" alt="image" src="https://github.com/user-attachments/assets/2df612d7-0eeb-4be1-9b60-c52d86f66f30" />

Successful install of this package from excel-rater-to-api on this commit: 
<img width="468" height="202" alt="image" src="https://github.com/user-attachments/assets/e926d121-8e76-4833-842a-c8c99ae31bac" />
